### PR TITLE
feat: cleanup diff between a remote_ref and checkout branch to avoid ref/head/<branch> confusion

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,30 +32,6 @@ inputs:
     default: 'github.com'
     description: GitHub hostname (useful for enterprise installations)
     required: false
-  commit_message:
-    default: 'Automated commit by GitHub Actions'
-    description: Commit message for the changes
-    required: false
-  force_push:
-    default: 'false'
-    description: Whether to force push (true/false)
-    required: false
-  target_branch:
-    default: ''
-    description: Name of the branch to push the code into
-    required: false
-  directory_path:
-    default: '.'
-    description: Path to the directory containing files to commit and push
-    required: false
-  remote_ref:
-    default: 'origin'
-    description: Remote repository reference
-    required: false
-  sign_commit:
-    default: 'false'
-    description: Whether to sign commits using GPG (true/false)
-    required: false
   author_name:
     default: 'GitHub Actions'
     description: Name of the commit author
@@ -63,6 +39,34 @@ inputs:
   author_email:
     default: 'github-actions@noreply.github.com'
     description: Email of the commit author
+    required: false
+  sign_commit:
+    default: 'false'
+    description: Whether to sign commits using GPG (true/false)
+    required: false
+  commit_message:
+    default: 'Automated commit by GitHub Actions'
+    description: Commit message for the changes
+    required: false
+  remote_ref:
+    default: 'origin'
+    description: Remote repository reference
+    required: false
+  branch_target:
+    default: 'main'
+    description: Name of the branch to push the code into
+    required: false
+  create_branch:
+    default: 'false'
+    description: Create branch if it does not exist
+    required: false
+  directory_path:
+    default: '.'
+    description: Path to the directory containing files to commit and push
+    required: false
+  force_push:
+    default: 'false'
+    description: Whether to force push (true/false)
     required: false
 
 outputs:

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,13 +24,14 @@ import { getInputValue } from './inputs.js';
   await new Action({
     [Input.AUTHOR_EMAIL]: getInputValue[Input.AUTHOR_EMAIL],
     [Input.AUTHOR_NAME]: getInputValue[Input.AUTHOR_NAME],
+    [Input.BRANCH_TARGET]: getInputValue[Input.BRANCH_TARGET],
     [Input.COMMIT_MESSAGE]: getInputValue[Input.COMMIT_MESSAGE],
+    [Input.CREATE_BRANCH]: getInputValue[Input.CREATE_BRANCH],
     [Input.DIRECTORY_PATH]: getInputValue[Input.DIRECTORY_PATH],
     [Input.FORCE_PUSH]: getInputValue[Input.FORCE_PUSH],
     [Input.GITHUB_HOSTNAME]: getInputValue[Input.GITHUB_HOSTNAME],
     [Input.GITHUB_TOKEN]: getInputValue[Input.GITHUB_TOKEN],
     [Input.REMOTE_REF]: getInputValue[Input.REMOTE_REF],
-    [Input.SIGN_COMMIT]: getInputValue[Input.SIGN_COMMIT],
-    [Input.TARGET_BRANCH]: getInputValue[Input.TARGET_BRANCH]
+    [Input.SIGN_COMMIT]: getInputValue[Input.SIGN_COMMIT]
   }).execute();
 })();

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -16,10 +16,24 @@ export const actionInputs: Record<Input, InputEntry> = {
     required: false,
     deprecationMessage: ''
   },
+  [Input.BRANCH_TARGET]: {
+    id: Input.BRANCH_TARGET,
+    description: 'The branch target to push the commit to',
+    default: 'main',
+    required: false,
+    deprecationMessage: ''
+  },
   [Input.COMMIT_MESSAGE]: {
     id: Input.COMMIT_MESSAGE,
     description: 'The commit message to use for the commit',
     default: 'Automated commit-and-push by GitHub Actions',
+    required: false,
+    deprecationMessage: ''
+  },
+  [Input.CREATE_BRANCH]: {
+    id: Input.CREATE_BRANCH,
+    description: 'Whether to create the branch if it is missing',
+    default: 'false',
     required: false,
     deprecationMessage: ''
   },
@@ -55,7 +69,7 @@ export const actionInputs: Record<Input, InputEntry> = {
   [Input.REMOTE_REF]: {
     id: Input.REMOTE_REF,
     description: 'The remote reference to use for the commit',
-    default: 'refs/heads/main',
+    default: 'origin',
     required: false,
     deprecationMessage: ''
   },
@@ -63,13 +77,6 @@ export const actionInputs: Record<Input, InputEntry> = {
     id: Input.SIGN_COMMIT,
     description: 'Whether to sign the commit',
     default: 'false',
-    required: false,
-    deprecationMessage: ''
-  },
-  [Input.TARGET_BRANCH]: {
-    id: Input.TARGET_BRANCH,
-    description: 'The target branch to push the commit to',
-    default: 'main',
     required: false,
     deprecationMessage: ''
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,14 +1,15 @@
 export enum Input {
-  GITHUB_TOKEN = 'github_token',
-  GITHUB_HOSTNAME = 'github_hostname',
-  COMMIT_MESSAGE = 'commit_message',
-  FORCE_PUSH = 'force_push',
-  TARGET_BRANCH = 'target_branch',
-  DIRECTORY_PATH = 'directory_path',
-  REMOTE_REF = 'remote_ref',
-  SIGN_COMMIT = 'sign_commit',
+  AUTHOR_EMAIL = 'author_email',
   AUTHOR_NAME = 'author_name',
-  AUTHOR_EMAIL = 'author_email'
+  BRANCH_TARGET = 'branch_target',
+  COMMIT_MESSAGE = 'commit_message',
+  CREATE_BRANCH = 'create_branch',
+  DIRECTORY_PATH = 'directory_path',
+  FORCE_PUSH = 'force_push',
+  GITHUB_HOSTNAME = 'github_hostname',
+  GITHUB_TOKEN = 'github_token',
+  REMOTE_REF = 'remote_ref',
+  SIGN_COMMIT = 'sign_commit'
 }
 
 export enum GitCommand {

--- a/src/utils/common.spec.ts
+++ b/src/utils/common.spec.ts
@@ -1,0 +1,20 @@
+import { ensureQuoted } from './common.js';
+
+describe('Common', () => {
+  describe('ensureQuoted', () => {
+    it.each([
+      ['hello', '"hello"'],
+      ['world', '"world"'],
+      ['123', '"123"'],
+      ['"', '"""'],
+      ["'", '"\'"'],
+      ['\n', '"\n"'],
+      ['\t', '"\t"'],
+      ['\\', '"\\"'],
+      ['hello world', '"hello world"'],
+      ['hello\nworld', '"hello\nworld"']
+    ])('should ensure that %s is quoted as %s', (input, expected) =>
+      expect(ensureQuoted(input)).toBe(expected)
+    );
+  });
+});

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,5 +1,19 @@
-export function ensureQuoted(value: string): string {
-  const hasDoubleQuotes = value.startsWith('"') && value.endsWith('"');
-  const hasSingleQuotes = value.startsWith("'") && value.endsWith("'");
-  return hasDoubleQuotes || hasSingleQuotes ? value : `"${value}"`;
+enum Quote {
+  SINGLE = "'",
+  DOUBLE = '"'
+}
+
+export function ensureQuoted(value: string, quote = Quote.DOUBLE): string {
+  const length = value.length;
+  const hasDoubleQuotes =
+    length > 1 &&
+    value.startsWith(Quote.DOUBLE) &&
+    value.endsWith(Quote.DOUBLE);
+  const hasSingleQuotes =
+    length > 1 &&
+    value.startsWith(Quote.SINGLE) &&
+    value.endsWith(Quote.SINGLE);
+  return hasDoubleQuotes || hasSingleQuotes
+    ? value
+    : [quote, value, quote].join('');
 }


### PR DESCRIPTION
# Pull Request

## Description

- simplify confusion between a remote ref and when a branch ref should be used

## Checklist

- [x] Changes have been tested locally.
- [x] Documentation has been updated accordingly.
- [x] Changes have been verified to have no runtime errors.
